### PR TITLE
fix: untranslated strings made it into messages.json

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -99,6 +99,16 @@ function writeLocales (locales, params, callback) {
       if (locales.hasOwnProperty(key)) {
         json = locales[key];
         jsonPath = path.join(params.dirPath, json.localeName, 'messages.json');
+
+        // remove empty messages
+        for (var msg_key in json.messages) {
+          if (json.messages.hasOwnProperty(msg_key)) {
+            if (json.messages[msg_key]['message'] == undefined) {
+              delete json.messages[msg_key];
+            }
+          }
+        }
+
         fs.outputJsonSync(jsonPath, json.messages);
         if (params.debug) {
           log('Created file', jsonPath, json.messages);


### PR DESCRIPTION
If a language column is empty, the package still writes that message:

![selection_002](https://cloud.githubusercontent.com/assets/119675/18103933/f2999f14-6f22-11e6-840d-6c820f1e7d3b.png)

This will result in `messages.json` full of items like this:

```
 {"options_enter_email_and_password": {"description": ""}, ...
```

Chrome finds the key in the object and tries to get `message` property, which is undefined. The extension is uncaght and completely crashes the extension.

(Если в файле CSV пустая колонка с языком, все эти ключи всё равно появляются в файле перевода, Хром их находит, пытается прочитать - но ключ message пуст, эктеншен просто падает.)
